### PR TITLE
Add levergaing to_data example

### DIFF
--- a/examples/leveraging_to_data_method/levaraging_to_data_method.py
+++ b/examples/leveraging_to_data_method/levaraging_to_data_method.py
@@ -12,6 +12,7 @@ if __name__ == "__main__":
     # Set headless to False to see the browser in action
     driver = PlaywrightWebDriver(headless=False)
 
+    # Define the queries to interact with the page
     QUERY = """
     {
         stock_info


### PR DESCRIPTION
Adding an example to show the capability of to_data() API. In cases like stock data monitoring, it has a perfect usecase. 
The obtained output is as follows, owing to leveraging the to_data API!
```
{'price': '$ 143.80', 'change': '-0.29', 'change_percent': '-0.20%', 'market_cap': '$1.78T', 'volume': '793.64K'}
```

The normal response is as follows:
```
{
  "stock_info": {
    "price": {
      "role": "heading",
      "tf623_id": "986",
      "html_tag": "h2",
      "name": "$ 143.80",
      "attributes": {
        "class": "intraday__price "
      }
    },
    "change": {
      "role": "generic",
      "tf623_id": "992",
      "html_tag": "bg-quote",
      "name": "-0.29",
      "attributes": {
        "field": "change",
        "format": "0,0.00",
        "channel": "/zigman2/quotes/202490156/composite",
        "session": "after"
      }
    },
    "change_percent": {
      "role": "generic",
      "tf623_id": "994",
      "html_tag": "bg-quote",
      "name": "-0.20%",
      "attributes": {
        "field": "percentchange",
        "format": "0,0.00%",
        "channel": "/zigman2/quotes/202490156/composite",
        "session": "after"
      }
    },
    "market_cap": {
      "role": "generic",
      "tf623_id": "1403",
      "html_tag": "span",
      "name": "$1.78T",
      "attributes": {
        "class": "primary "
      }
    },
    "volume": {
      "role": "generic",
      "tf623_id": "998",
      "html_tag": "bg-quote",
      "name": "793.64K",
      "attributes": {
        "field": "volume",
        "channel": "/zigman2/quotes/202490156/composite",
        "session": "after"
      }
    }
  }
}
```