### PR TITLE
Migrate to agentql 0.4.x

### DIFF
--- a/application_examples/flight_price_tracker/flight_price_tracker.py
+++ b/application_examples/flight_price_tracker/flight_price_tracker.py
@@ -1,6 +1,5 @@
 """"This is an example of how to use AgentQL to track the cheapest flight price from Skyscanner website."""
 import agentql
-from agentql.ext.playwright import PlaywrightWebDriverSync
 
 # Set the URL to the desired website (Skyscanner in this case)
 URL = "https://www.skyscanner.co.in/"
@@ -13,18 +12,15 @@ USER_AGENT_INFO = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/5
 
 if __name__ == "__main__":
 
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriverSync(headless=False)
+    # Start a session with the specified URL
+    session = agentql.start_session(URL)
 
     # Enable stealth mode to prevent bot detection by the website
-    driver.enable_stealth_mode(
+    session.driver.enable_stealth_mode(
         webgl_vendor=VENDOR_INFO,
         webgl_renderer=RENDERER_INFO,
         nav_user_agent=USER_AGENT_INFO,
         )
-
-    # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(URL, web_driver=driver)
     
     # Define the queries to interact with the page (You could tweak the queries as per item you want to track on the website)
     QUERY_1 = """
@@ -109,7 +105,7 @@ if __name__ == "__main__":
     response_6 = session.query(QUERY_6)
 
     # Scroll the page to click on the apply button
-    driver.scroll_page(scroll_direction="DOWN")
+    session.driver.scroll_page(scroll_direction="DOWN")
 
     response_6.apply_btn.click(force=True)
 

--- a/application_examples/flight_price_tracker/flight_price_tracker.py
+++ b/application_examples/flight_price_tracker/flight_price_tracker.py
@@ -1,6 +1,6 @@
 """"This is an example of how to use AgentQL to track the cheapest flight price from Skyscanner website."""
 import agentql
-from agentql.sync_api.web import PlaywrightWebDriver
+from agentql.ext.playwright import PlaywrightWebDriverSync
 
 # Set the URL to the desired website (Skyscanner in this case)
 URL = "https://www.skyscanner.co.in/"
@@ -14,7 +14,7 @@ USER_AGENT_INFO = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/5
 if __name__ == "__main__":
 
     # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
+    driver = PlaywrightWebDriverSync(headless=False)
 
     # Enable stealth mode to prevent bot detection by the website
     driver.enable_stealth_mode(

--- a/application_examples/flight_price_tracker/flight_price_tracker.py
+++ b/application_examples/flight_price_tracker/flight_price_tracker.py
@@ -1,5 +1,6 @@
 """"This is an example of how to use AgentQL to track the cheapest flight price from Skyscanner website."""
 import agentql
+from agentql.sync_api import ScrollDirection
 
 # Set the URL to the desired website (Skyscanner in this case)
 URL = "https://www.skyscanner.co.in/"
@@ -105,7 +106,7 @@ if __name__ == "__main__":
     response_6 = session.query(QUERY_6)
 
     # Scroll the page to click on the apply button
-    session.driver.scroll_page(scroll_direction="DOWN")
+    session.driver.scroll_page(ScrollDirection.DOWN)
 
     response_6.apply_btn.click(force=True)
 

--- a/application_examples/sentiment_analysis_youtube_comments.py
+++ b/application_examples/sentiment_analysis_youtube_comments.py
@@ -1,15 +1,14 @@
 from openai import OpenAI
 import agentql
-from agentql.sync_api.web import PlaywrightWebDriver
 
 URL = "https://www.youtube.com/watch?v=JfM1mr2bCuk"
 
 if __name__ == "__main__":
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
 
     # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(URL, web_driver=driver)
+    session = agentql.start_session(URL)
+
+    driver = session.driver
 
     # (Note: The current script is configured to load about 100 comments on the video)
     for i in range(5):

--- a/application_examples/xpath/xpath.py
+++ b/application_examples/xpath/xpath.py
@@ -1,6 +1,7 @@
 import agentql
 
 #import https://pypi.org/project/playwright-dompath/ 
+# Playwright Dompath is a Python library that helps you to generate XPath from Playwright selectors.
 from playwright_dompath.dompath_sync import xpath_path
 
 session = agentql.start_session("https://www.google.com")

--- a/examples/async_example/async_example.py
+++ b/examples/async_example/async_example.py
@@ -2,14 +2,10 @@
 import agentql
 import asyncio
 
-# Importing the default PlaywrightWebDriver from AgentQL library
-from agentql.async_api.web import PlaywrightWebDriver
-
 # Set the URL to the desired website
-AMAZON_URL = "https://www.amazon.com/Nintendo-Switch-OLED-Model-Neon-Joy/dp/B098RL6SBJ/ref=sr_1_2?crid=M1VXR6B580N1&dib=eyJ2IjoiMSJ9.SnJwwaQgWAAz2ipQdcQ--1oD_RFW8sY6H0aMKBzxU62fEEvvrjWWwIInVKw0QRI6Fr9rneWqEj5IVALwzoalaRjoQECDjlhSdCBv8OMJnX27l2_uIaUDVj1iq0Idz4iuxHv9FAxGUqOcIgeXMovxLr9d955NZoMr2Jm-HLEhtYx6P6es96OOMWd8y0Ufofumsilu4dp_sAyaHKAUU59ubjhN1iUFeSIaX-h_xYHLb5k.PM2S_-8ic6AIy9ooBoUCx7_3ooOZytd_8L_GOpXjRcc&dib_tag=se&keywords=nintendo+switch&qid=1708647744&sprefix=nintendo+switch%2Caps%2C308&sr=8-2" 
+WALMART_URL = "https://www.walmart.com/ip/Nintendo-Switch-OLED-Model-w-White-Joy-Con/910582148?athbdg=L1600"
 TARGET_URL = "https://www.target.com/p/nintendo-switch-oled-model-with-white-joy-con/-/A-83887639#lnk=sametab"
 NINETENDO_URL = "https://www.nintendo.com/us/store/products/nintendo-switch-oled-model-white-set/"
-
 
 def print_header():
     """Prints the header for the data table"""
@@ -21,9 +17,8 @@ def print_row(website, product, price):
     print(f"{website:<25} | {product:<20} | {price:<20} ")
 
 async def fetch_price(session_url, query):
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
-    session = await agentql.start_async_session(session_url, web_driver=driver)
+    session = await agentql.start_async_session(session_url)
+    await session.driver.wait_for_page_ready_state()
     response = await session.query(query)
     data = await response.nintendo_switch.to_data()
     await session.stop()
@@ -44,13 +39,13 @@ async def get_price_across_websites():
     print_header()
 
     # Fetch prices concurrently
-    amazon_price, nintendo_price, target_price = await asyncio.gather(
-        fetch_price(AMAZON_URL, PRODUCT_INFO_QUERY),
+    walmart_price, nintendo_price, target_price = await asyncio.gather(
+        fetch_price(WALMART_URL, PRODUCT_INFO_QUERY),
         fetch_price(NINETENDO_URL, PRODUCT_INFO_QUERY),
         fetch_price(TARGET_URL, PRODUCT_INFO_QUERY)
     )
 
-    print_row("Amazon", "Nintendo Switch", amazon_price)
+    print_row("Walmart", "Nintendo Switch", walmart_price)
     print_row("Nintendo site", "Nintendo Switch", nintendo_price)
     print_row("Target", "Nintendo Switch", target_price)
 

--- a/examples/customizing_web_driver/customizing_web_driver.py
+++ b/examples/customizing_web_driver/customizing_web_driver.py
@@ -1,21 +1,31 @@
 """This example demonstrates how to customize the web driver used by AgentQL."""
-import time
 import agentql
 
 # Importing the default PlaywrightWebDriver from AgentQL library
-from agentql.sync_api.web import PlaywrightWebDriver
+from agentql.ext.playwright import PlaywrightWebDriverSync
 
 # Set the URL to the desired website
 URL = "https://www.google.com"
 
 if __name__ == "__main__":
 
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
+    # Set headless to True to hide the browser and run the script in the background
+    driver = PlaywrightWebDriverSync(headless=True)
 
     # Start a session with the specified URL and the custom driver
     session = agentql.start_session(URL, web_driver=driver)
 
-    # Wait for 5 seconds to see the browser in action
-    time.sleep(5)
+    # Define the queries to interact with the page
+    QUERY = """
+    {
+        search_input
+        search_btn
+    }"""
 
+    response = session.query(QUERY)
+
+    # This is just to demonstrate that browser was running in the background and we get the response object successfully
+    print(response.to_data())
+
+    # Stop the session
+    session.stop()

--- a/examples/default_driver/default_driver.py
+++ b/examples/default_driver/default_driver.py
@@ -1,4 +1,4 @@
-"""This example demonstrates how to work with default web driver configuration (headless) used by AgentQL."""
+"""This example demonstrates how to work with web driver configuration (headless) used by AgentQL."""
 import agentql
 
 # Set the URL to the desired website
@@ -32,5 +32,8 @@ if __name__ == "__main__":
     response = session.query(QUERY)
 
     print(response)
+
+    # Stop the session
+    session.stop()
 
 

--- a/examples/default_popup_handler/default_popup_handler.py
+++ b/examples/default_popup_handler/default_popup_handler.py
@@ -2,18 +2,14 @@
 import time
 import agentql
 
-from agentql.sync_api.web import PlaywrightWebDriver
 from agentql.sync_api import close_all_popups_handler
 
 # Set the URL to the desired website
-URL = "https://bonobos.com/"
+URL = "https://kinfield.com/"
 
 if __name__ == "__main__":
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
-
-    # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(URL, web_driver=driver)
+    
+    session = agentql.start_session(URL)
 
     # Define the queries to interact with the page
     QUERY = """

--- a/examples/leveraging_to_data_method/levaraging_to_data_method.py
+++ b/examples/leveraging_to_data_method/levaraging_to_data_method.py
@@ -1,16 +1,10 @@
 """This example demonstrates how to leverage to_data() method provided by AgentQL."""
 import agentql
 
-# Importing the default PlaywrightWebDriver from AgentQL library
-from agentql.sync_api.web import PlaywrightWebDriver
-
 # Set the URL to the desired website
 URL = "https://www.marketwatch.com/investing/stock/googl?mod=search_symbol"
 
 if __name__ == "__main__":
-
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
 
     # Define the queries to interact with the page
     QUERY = """
@@ -26,7 +20,7 @@ if __name__ == "__main__":
     }"""
 
     # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(URL, web_driver=driver)
+    session = agentql.start_session(URL)
 
     # Make API call(s) to AgentQL server to fetch the query
     response = session.query(QUERY)

--- a/examples/login/login.py
+++ b/examples/login/login.py
@@ -1,6 +1,5 @@
 import time
 import agentql
-from agentql.sync_api.web import PlaywrightWebDriver
 
 URL = "https://www.target.com"
 EMAIL = "REPLACE_WITH_YOUR_EMAIL (For target.com)"
@@ -8,11 +7,8 @@ PASSWORD = "REPLACE_WITH_YOUR_PASSWORD (For target.com)"
 
 if __name__ == "__main__":
 
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
-
-    # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(URL, web_driver=driver)
+    # Start a session with the specified URL
+    session = agentql.start_session(URL)
 
     # Define the queries to interact with the page
     sign_in_query = """

--- a/examples/same_query_across_sites/same_query_across_sites.py
+++ b/examples/same_query_across_sites/same_query_across_sites.py
@@ -1,11 +1,8 @@
 """This example demonstrates how to levergae to_data() method provided by AgentQL."""
 import agentql
 
-# Importing the default PlaywrightWebDriver from AgentQL library
-from agentql.sync_api.web import PlaywrightWebDriver
-
 # Set the URL to the desired website
-AMAZON_URL = "https://www.amazon.com/Nintendo-Switch-OLED-Model-Neon-Joy/dp/B098RL6SBJ/ref=sr_1_2?crid=M1VXR6B580N1&dib=eyJ2IjoiMSJ9.SnJwwaQgWAAz2ipQdcQ--1oD_RFW8sY6H0aMKBzxU62fEEvvrjWWwIInVKw0QRI6Fr9rneWqEj5IVALwzoalaRjoQECDjlhSdCBv8OMJnX27l2_uIaUDVj1iq0Idz4iuxHv9FAxGUqOcIgeXMovxLr9d955NZoMr2Jm-HLEhtYx6P6es96OOMWd8y0Ufofumsilu4dp_sAyaHKAUU59ubjhN1iUFeSIaX-h_xYHLb5k.PM2S_-8ic6AIy9ooBoUCx7_3ooOZytd_8L_GOpXjRcc&dib_tag=se&keywords=nintendo+switch&qid=1708647744&sprefix=nintendo+switch%2Caps%2C308&sr=8-2" 
+WALMART_URL = "https://www.walmart.com/ip/Nintendo-Switch-OLED-Model-w-White-Joy-Con/910582148?athbdg=L1600"
 TARGET_URL = "https://www.target.com/p/nintendo-switch-oled-model-with-white-joy-con/-/A-83887639#lnk=sametab"
 NINETENDO_URL = "https://www.nintendo.com/us/store/products/nintendo-switch-oled-model-white-set/"
 
@@ -21,9 +18,6 @@ def print_row(website, product, price):
 
 if __name__ == "__main__":
 
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
-
     # Define the queries to interact with the page
     PRODUCT_INFO_QUERY = """
     {
@@ -36,7 +30,7 @@ if __name__ == "__main__":
     print_header()
 
     # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(AMAZON_URL, web_driver=driver)
+    session = agentql.start_session(WALMART_URL)
 
     # Make API call(s) to AgentQL server to fetch the query
     response = session.query(PRODUCT_INFO_QUERY)
@@ -44,13 +38,13 @@ if __name__ == "__main__":
     # Leveraging to_data() method to extract the data from the response
     data = response.nintendo_switch.to_data()
 
-    print_row("Amazon", "Nintendo Switch", data["price"])
+    print_row("Walmart", "Nintendo Switch", data["price"])
 
     # Stop the session
     session.stop()
 
     # Start a session with the new URL and the same driver
-    session = agentql.start_session(NINETENDO_URL, web_driver=driver)
+    session = agentql.start_session(NINETENDO_URL)
 
     # Reuse the same query to fetch the data from the new website
     response = session.query(PRODUCT_INFO_QUERY)
@@ -63,7 +57,7 @@ if __name__ == "__main__":
     session.stop()
 
     # Repeat the same process for other websites
-    session = agentql.start_session(TARGET_URL, web_driver=driver)
+    session = agentql.start_session(TARGET_URL)
 
     response = session.query(PRODUCT_INFO_QUERY)
 

--- a/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
+++ b/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
@@ -1,25 +1,21 @@
 """This example demonstrates how to wait for the page to load before querying the page and levergae scroll method."""
 import agentql
 
-from agentql.sync_api.web import PlaywrightWebDriver
-
 # Yotube video URL to demonstrate the example for loading comments on the video
 URL = "https://www.youtube.com/watch?v=F6hmwkI3n64"
 
 if __name__ == "__main__":
-    # Set headless to False to see the browser in action
-    driver = PlaywrightWebDriver(headless=False)
-
+    
     # Start a session with the specified URL and the custom driver
-    session = webql.start_session(URL, web_driver=driver)
+    session = agentql.start_session(URL)
 
     # (Note: The current script is configured to load about 100 comments on the video)
     for i in range(5):
         #  Each Scroll will load about 20 comments on the video
-        driver.scroll_to_bottom()
+        session.driver.scroll_to_bottom()
 
         # Wait for the page to load (helps to load the comments on the video)
-        driver.wait_for_page_ready_state()
+        session.driver.wait_for_page_ready_state()
 
     QUERY = """
     {

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "agentql"
-version = "0.3.0"
+version = "0.4.1"
 description = "Tiny Fish AgentQL Python Client"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "agentql-0.3.0-py3-none-any.whl", hash = "sha256:3a72e6eb9728a72c594d6f3dea6b3404f9dbdb1d7fd8d9c130d60e9f99de05ee"},
-    {file = "agentql-0.3.0.tar.gz", hash = "sha256:7660788bc2c42f74511a3f0edad4ad1c02aa16f829fee3033b6f13355196bcba"},
+    {file = "agentql-0.4.1-py3-none-any.whl", hash = "sha256:778c981ed00c6c85679bcf1db948220d5c835654a4aef3df1683f97f57865eed"},
+    {file = "agentql-0.4.1.tar.gz", hash = "sha256:579ed29204c3c5d6c8e5fffec69079817f46375de1709c49e59f7c5a1bc63a09"},
 ]
 
 [package.dependencies]
@@ -41,9 +41,6 @@ files = [
     {file = "annotated_types-0.6.0-py3-none-any.whl", hash = "sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43"},
     {file = "annotated_types-0.6.0.tar.gz", hash = "sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "anyio"
@@ -297,13 +294,13 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.4"
+version = "1.0.5"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.4-py3-none-any.whl", hash = "sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73"},
-    {file = "httpcore-1.0.4.tar.gz", hash = "sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022"},
+    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
+    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
 ]
 
 [package.dependencies]
@@ -314,7 +311,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.25.0)"]
+trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
@@ -363,14 +360,59 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "1.26.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+]
+
+[[package]]
 name = "openai"
-version = "1.14.3"
+version = "1.16.2"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.14.3-py3-none-any.whl", hash = "sha256:7a465994a7ccf677a110c6cc2ef9d86229bad42c060b585b67049aa749f3b774"},
-    {file = "openai-1.14.3.tar.gz", hash = "sha256:37b514e9c0ff45383ec9b242abd0f7859b1080d4b54b61393ed341ecad1b8eb9"},
+    {file = "openai-1.16.2-py3-none-any.whl", hash = "sha256:46a435380921e42dae218d04d6dd0e89a30d7f3b9d8a778d5887f78003cf9354"},
+    {file = "openai-1.16.2.tar.gz", hash = "sha256:c93d5efe5b73b6cb72c4cd31823852d2e7c84a138c0af3cbe4a8eb32b1164ab2"},
 ]
 
 [package.dependencies]
@@ -397,6 +439,79 @@ files = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.2.1"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8df8612be9cd1c7797c93e1c5df861b2ddda0b48b08f2c3eaa0702cf88fb5f88"},
+    {file = "pandas-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0f573ab277252ed9aaf38240f3b54cfc90fff8e5cab70411ee1d03f5d51f3944"},
+    {file = "pandas-2.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f02a3a6c83df4026e55b63c1f06476c9aa3ed6af3d89b4f04ea656ccdaaaa359"},
+    {file = "pandas-2.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c38ce92cb22a4bea4e3929429aa1067a454dcc9c335799af93ba9be21b6beb51"},
+    {file = "pandas-2.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c2ce852e1cf2509a69e98358e8458775f89599566ac3775e70419b98615f4b06"},
+    {file = "pandas-2.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53680dc9b2519cbf609c62db3ed7c0b499077c7fefda564e330286e619ff0dd9"},
+    {file = "pandas-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:94e714a1cca63e4f5939cdce5f29ba8d415d85166be3441165edd427dc9f6bc0"},
+    {file = "pandas-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f821213d48f4ab353d20ebc24e4faf94ba40d76680642fb7ce2ea31a3ad94f9b"},
+    {file = "pandas-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c70e00c2d894cb230e5c15e4b1e1e6b2b478e09cf27cc593a11ef955b9ecc81a"},
+    {file = "pandas-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e97fbb5387c69209f134893abc788a6486dbf2f9e511070ca05eed4b930b1b02"},
+    {file = "pandas-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101d0eb9c5361aa0146f500773395a03839a5e6ecde4d4b6ced88b7e5a1a6403"},
+    {file = "pandas-2.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7d2ed41c319c9fb4fd454fe25372028dfa417aacb9790f68171b2e3f06eae8cd"},
+    {file = "pandas-2.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:af5d3c00557d657c8773ef9ee702c61dd13b9d7426794c9dfeb1dc4a0bf0ebc7"},
+    {file = "pandas-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:06cf591dbaefb6da9de8472535b185cba556d0ce2e6ed28e21d919704fef1a9e"},
+    {file = "pandas-2.2.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:88ecb5c01bb9ca927ebc4098136038519aa5d66b44671861ffab754cae75102c"},
+    {file = "pandas-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:04f6ec3baec203c13e3f8b139fb0f9f86cd8c0b94603ae3ae8ce9a422e9f5bee"},
+    {file = "pandas-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a935a90a76c44fe170d01e90a3594beef9e9a6220021acfb26053d01426f7dc2"},
+    {file = "pandas-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c391f594aae2fd9f679d419e9a4d5ba4bce5bb13f6a989195656e7dc4b95c8f0"},
+    {file = "pandas-2.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9d1265545f579edf3f8f0cb6f89f234f5e44ba725a34d86535b1a1d38decbccc"},
+    {file = "pandas-2.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:11940e9e3056576ac3244baef2fedade891977bcc1cb7e5cc8f8cc7d603edc89"},
+    {file = "pandas-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4acf681325ee1c7f950d058b05a820441075b0dd9a2adf5c4835b9bc056bf4fb"},
+    {file = "pandas-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9bd8a40f47080825af4317d0340c656744f2bfdb6819f818e6ba3cd24c0e1397"},
+    {file = "pandas-2.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:df0c37ebd19e11d089ceba66eba59a168242fc6b7155cba4ffffa6eccdfb8f16"},
+    {file = "pandas-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:739cc70eaf17d57608639e74d63387b0d8594ce02f69e7a0b046f117974b3019"},
+    {file = "pandas-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9d3558d263073ed95e46f4650becff0c5e1ffe0fc3a015de3c79283dfbdb3df"},
+    {file = "pandas-2.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4aa1d8707812a658debf03824016bf5ea0d516afdea29b7dc14cf687bc4d4ec6"},
+    {file = "pandas-2.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:76f27a809cda87e07f192f001d11adc2b930e93a2b0c4a236fde5429527423be"},
+    {file = "pandas-2.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:1ba21b1d5c0e43416218db63037dbe1a01fc101dc6e6024bcad08123e48004ab"},
+    {file = "pandas-2.2.1.tar.gz", hash = "sha256:0ab90f87093c13f3e8fa45b48ba9f39181046e8f3317d3aadb2fffbb1b978572"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.7"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
+
+[[package]]
 name = "playwright"
 version = "1.42.0"
 description = "A high-level API to automate web browsers"
@@ -415,6 +530,23 @@ files = [
 [package.dependencies]
 greenlet = "3.0.3"
 pyee = "11.0.1"
+
+[[package]]
+name = "playwright-dompath"
+version = "0.0.1"
+description = "Retrieve xpath and css selectors from Locator objects in Playwright"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "playwright-dompath-0.0.1.tar.gz", hash = "sha256:42aa141e07698c8b55e9bb4240bd474424cfd70fa8201130e18aa7f548aa4686"},
+    {file = "playwright_dompath-0.0.1-py3-none-any.whl", hash = "sha256:a5b2a289e8646a486412d276b6e134cef264ae7e15cfe4f40359c69f47b1366e"},
+]
+
+[package.dependencies]
+playwright = ">=1.22.0"
+
+[package.extras]
+dev = ["black", "isort", "pip-tools", "pytest"]
 
 [[package]]
 name = "pluggy"
@@ -599,6 +731,31 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pytz"
+version = "2024.1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
+    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
+]
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -618,6 +775,17 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "sniffio"
@@ -680,13 +848,24 @@ telegram = ["requests"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.10.0"
+version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
-    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
+]
+
+[[package]]
+name = "tzdata"
+version = "2024.1"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
+    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
 ]
 
 [[package]]
@@ -708,5 +887,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "da52f9cdd191c5a1b9ae175e2289003cec817746bd036c80c392318c5b2e9b7c"
+python-versions = "^3.9"
+content-hash = "64696aadb100f13cec12b3c4080dab193118d7f1f15f11cfd304c1813a780e8c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,11 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
-agentql = "^0.3.0"
+python = "^3.9"
+agentql = "^0.4.0"
 openai = "^1.13.3"
+playwright-dompath = "^0.0.1"
+pandas = "^2.2.1"
 
 
 [build-system]


### PR DESCRIPTION
Migrating fish-tank examples to agentql 0.4.x. There are two examples, `pandas.py` and `google_colab.py`. I'll check with @justinzw to help migrating those two examples. All the other examples have been migrated to the latest version. 

We updated the python version required to `3.9` from `3.8` owing to one of the libraries used in one of the examples had this requirement. (We initially, were tied to `3.8` as minimum version for agentql to be compatible is `3.8`). 