### PR TITLE
TF-1598 Update wait for page load example

### DIFF
--- a/examples/wait_for_entire_page_load/README.md
+++ b/examples/wait_for_entire_page_load/README.md
@@ -1,0 +1,16 @@
+# Example script: wait for page to load with AgentQL
+
+This example demonstrates how to wait for the page to load completely before querying the page.
+
+## Run the script
+
+* [Install AgentQL SDK](https://docs.agentql.com/docs/installation/sdk-installation)
+* Save this python file locally as **wait_for_entire_page_load.py**
+* Run the following command from the project's folder:
+```bash
+python3 wait_for_entire_page_load.py
+```
+
+## Play with it
+
+Install the [AgentQL Chrome DevTools extension](https://docs.agentql.com/docs/installation/chrome-extension-installation/) to play with the AgentQL query. [Learn more about the AgentQL query language](https://docs.agentql.com/docs/agentql-query/query-intro)

--- a/examples/wait_for_entire_page_load/README.md
+++ b/examples/wait_for_entire_page_load/README.md
@@ -11,6 +11,6 @@ This example demonstrates how to wait for the page to load completely before que
 python3 wait_for_entire_page_load.py
 ```
 
-## Play with it
+## Play with the query
 
 Install the [AgentQL Chrome DevTools extension](https://docs.agentql.com/docs/installation/chrome-extension-installation/) to play with the AgentQL query. [Learn more about the AgentQL query language](https://docs.agentql.com/docs/agentql-query/query-intro)

--- a/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
+++ b/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
@@ -3,7 +3,7 @@
 from agentql.ext.playwright.sync_api import Page
 from playwright.sync_api import sync_playwright
 
-# Yotube video URL to demonstrate the example for loading comments on the video
+# Duckduckgo URL to demonstrate the example for loading more videos on the page
 URL = "https://duckduckgo.com/?q=machine+learning+lectures+mit&t=h_&iar=videos&iax=videos&ia=videos"
 
 QUERY = """
@@ -18,22 +18,24 @@ QUERY = """
 
 
 def main():
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=False)
 
-        # Create a new AgentQL page instance in the browser for web interactions
-        page: Page = browser.new_page()
+        # Create a new page in the broswer and cast it to custom Page type to get access to the AgentQL's querying API
+        page: Page = browser.new_page()  # type: ignore
+
         page.goto(URL)
 
         for _ in range(2):
-            # Wait for the page to load (helps to load the additional videos)
+            # Wait for additional videos to load completely
             page.wait_for_page_ready_state()
             # Scroll down the page to trigger loading of more videos
             page.keyboard.press("End")
 
+        # # Use query_data() method to fetch video lists data from the page
         response = page.query_data(QUERY)
 
-        # Print the first video details
+        # Print the details of the first video
         print(response["videos"][0])
 
         browser.close()

--- a/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
+++ b/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
@@ -1,35 +1,43 @@
-"""This example demonstrates how to wait for the page to load before querying the page and levergae scroll method."""
-import agentql
+"""This example demonstrates how to wait for the page to load completely before querying the page."""
+
+from agentql.ext.playwright.sync_api import Page
+from playwright.sync_api import sync_playwright
 
 # Yotube video URL to demonstrate the example for loading comments on the video
 URL = "https://www.youtube.com/watch?v=F6hmwkI3n64"
 
-if __name__ == "__main__":
-    
-    # Start a session with the specified URL and the custom driver
-    session = agentql.start_session(URL)
-
-    # (Note: The current script is configured to load about 100 comments on the video)
-    for i in range(5):
-        #  Each Scroll will load about 20 comments on the video
-        session.driver.scroll_to_bottom()
-
-        # Wait for the page to load (helps to load the comments on the video)
-        session.driver.wait_for_page_ready_state()
-
-    QUERY = """
-    {
-        comments[] {
-            comment_title
-            author
-            date
-        }
+QUERY = """
+{
+    comments[] {
+        comment_content
+        author
+        date
     }
-    """
+}
+"""
 
-    response = session.query(QUERY)
 
-    # TODO: Add appropriate code for consumtpion of the comments data
-    # Example: Levergae AgentQL's to_data() method to extract the content of comments and do sentiment analysis of the comments on the video
-    print(response.to_data())
-    session.stop()
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+
+        # Create a new AgentQL page instance in the browser for web interactions
+        page: Page = browser.new_page()
+        page.goto(URL)
+
+        for _ in range(3):
+            # Wait for the page to load (helps to load the comments on the video)
+            page.wait_for_page_ready_state()
+            # Scroll down the page to trigger loading of comments
+            page.keyboard.press("PageDown")
+
+        response = page.query_data(QUERY)
+
+        # Print the first comment
+        print(response["comments"][0])
+
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
+++ b/examples/wait_for_entire_page_load/wait_for_entire_page_load.py
@@ -4,14 +4,14 @@ from agentql.ext.playwright.sync_api import Page
 from playwright.sync_api import sync_playwright
 
 # Yotube video URL to demonstrate the example for loading comments on the video
-URL = "https://www.youtube.com/watch?v=F6hmwkI3n64"
+URL = "https://duckduckgo.com/?q=machine+learning+lectures+mit&t=h_&iar=videos&iax=videos&ia=videos"
 
 QUERY = """
 {
-    comments[] {
-        comment_content
-        author
-        date
+    videos(first 10 videos)[] {
+        video_title
+        length
+        views
     }
 }
 """
@@ -25,16 +25,16 @@ def main():
         page: Page = browser.new_page()
         page.goto(URL)
 
-        for _ in range(3):
-            # Wait for the page to load (helps to load the comments on the video)
+        for _ in range(2):
+            # Wait for the page to load (helps to load the additional videos)
             page.wait_for_page_ready_state()
-            # Scroll down the page to trigger loading of comments
-            page.keyboard.press("PageDown")
+            # Scroll down the page to trigger loading of more videos
+            page.keyboard.press("End")
 
         response = page.query_data(QUERY)
 
-        # Print the first comment
-        print(response["comments"][0])
+        # Print the first video details
+        print(response["videos"][0])
 
         browser.close()
 


### PR DESCRIPTION
This fixes [TF-1598.](https://linear.app/tinyfish/issue/TF-1598/update-wait-for-page-load-example-in-fish-tank)

This fixes `wait_for_page_load.py` example, which demonstrates how to use `wait_for_page_ready_state()` method to reliably load lazy-loading contents. This PR updates the website to https://duckduckgo.com/?q=machine+learning+lectures+mit&t=h_&iar=videos&iax=videos&ia=videos and use `page.keyboard.press('End')` to scroll the page instead of previous `scroll_to_bottom()` method, which has been deprecated. In addition, Smart Locator API is used.