### PR TITLE
Add .vscode folder to fishtank

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "ms-python.black-formatter",
+    "GitHub.copilot",
+    "esbenp.prettier-vscode",
+    "ms-python.isort",
+    "ms-python.pylint"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
       }
     },
     {
-      "name": "Python Debugger: Python File",
+      "name": "Python: Debug Current File",
       "type": "debugpy",
       "request": "launch",
       "program": "${file}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Run Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}"
+      }
+    },
+    {
+      "name": "Python Debugger: Python File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}"
+      }
+    },
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,29 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "black-formatter.args": [
+    "--line-length=100"
+  ],
+  "isort.args": [
+    "--line-length=100",
+    "--wrap-length=100",
+    "--multi-line=3",
+    "--trailing-comma",
+    "--profile=black"
+  ],
+  "pylint.importStrategy": "fromEnvironment",
+  "pylint.args": [
+    "--rcfile=.pylintrc"
+  ],
+  "python.analysis.typeCheckingMode": "standard",
+  "editor.rulers": [100]
+}


### PR DESCRIPTION
Add .vscode folder so that we could standardize extension recommendations, launch setup, vscode setting for extensions for all developers.

This is pretty much the same as other repos except:

(1) A ruler setting has been added to show 100 characters line
(2) Pytest settings have been removed since we don't have unit test now for fishtank