### PR TITLE
TF-2873 Update examples to page.wait_for_timeout()

### DIFF
--- a/examples/close_cookie_dialog/close_cookies.py
+++ b/examples/close_cookie_dialog/close_cookies.py
@@ -1,7 +1,5 @@
 """This example demonstrates how to close popup windows (like promotion form) with AgentQL."""
 
-import time
-
 import agentql
 from playwright.sync_api import sync_playwright
 
@@ -33,7 +31,7 @@ def main():
             response.cookies_form.reject_btn.click()
 
         # Wait for 10 seconds to see the browser in action
-        time.sleep(10)
+        page.wait_for_timeout(10000)
 
 
 if __name__ == "__main__":

--- a/examples/close_cookies/close_cookies.py
+++ b/examples/close_cookies/close_cookies.py
@@ -1,7 +1,5 @@
 """This example demonstrates how to close popup windows (like promotion form) with AgentQL."""
 
-import time
-
 import agentql
 from playwright.sync_api import sync_playwright
 
@@ -34,7 +32,7 @@ def main():
             response.cookies_form.reject_btn.click()
 
         # Wait for 10 seconds to see the browser in action
-        time.sleep(10)
+        page.wait_for_timeout(10000)
 
 
 if __name__ == "__main__":

--- a/examples/close_popup/close_popup.py
+++ b/examples/close_popup/close_popup.py
@@ -1,7 +1,5 @@
 """This example demonstrates how to close popup windows (like promotion form) with AgentQL."""
 
-import time
-
 import agentql
 from playwright.sync_api import sync_playwright
 
@@ -30,7 +28,7 @@ def main():
         # Click the close button to close the popup
         response.popup_form.close_btn.click()
         # Wait for 10 seconds to see the browser in action
-        time.sleep(10)
+        page.wait_for_timeout(10000)
 
 
 if __name__ == "__main__":

--- a/examples/first_steps/first_steps.py
+++ b/examples/first_steps/first_steps.py
@@ -2,8 +2,6 @@
 
 """This is an example of collecting pricing data from e-commerce website using AgentQL."""
 
-import time
-
 # Import the Page class from the AgentQL Playwright extension
 # This enables the use of the AgentQL Smart Locator and Data Query API
 import agentql
@@ -95,7 +93,7 @@ def _add_qwilfish_to_cart(page: Page):
         qwilfish_page_btn.click()
 
     # Wait for 10 seconds to see the browser action
-    time.sleep(10)
+    page.wait_for_timeout(10000)
 
 
 if __name__ == "__main__":

--- a/examples/save_and_load_authenticated_session/save_and_load_authenticated_state.py
+++ b/examples/save_and_load_authenticated_session/save_and_load_authenticated_state.py
@@ -1,7 +1,5 @@
 """This example demonstrates how to save and load a authenticated state (i.e. signed-in state) using AgentQL."""
 
-import time
-
 import agentql
 from playwright.sync_api import sync_playwright
 
@@ -65,7 +63,7 @@ def load_signed_in_state():
         page.wait_for_page_ready_state()
 
         # Wait for 10 seconds to see the signed-in page
-        time.sleep(10)
+        page.wait_for_timeout(10000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes TF-2873 by updating examples to use `page.wait_for_timeout()` instead of `time.sleep()`.