### PR TITLE
fix(security): bump requests 2.32.5→2.33.1 in examples/python (ENG-13360)

### DIFF
--- a/examples/python/poetry.lock
+++ b/examples/python/poetry.lock
@@ -1357,14 +1357,14 @@ dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "t
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+    {file = "requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"},
+    {file = "requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517"},
 ]
 
 [package.dependencies]

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -11,6 +11,7 @@ package-mode = false
 python = "^3.9"
 agentql = "*"
 openai = "^1.13.3"
+requests = ">=2.33.0"
 playwright-dompath = "^0.0.1"
 httpx = "*"
 


### PR DESCRIPTION
## Vulnerability Fixes

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| requests (examples/python) | 2.32.5 | 2.33.1 | [GHSA-9wx4-h78v-vm56](https://github.com/advisories/GHSA-9wx4-h78v-vm56) (CVE-2026-25645) | — | ✅ Fixed |

## Changes

- **examples/python/pyproject.toml**: Added `requests = ">=2.33.0"` floor pin
- **examples/python/poetry.lock**: Surgical update — requests 2.32.5 → 2.33.1

## Ticket
- ENG-13360 (MEDIUM, Dependabot alert #36)

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| requests | 2.32.5 | 2.33.1 | Patch/security | Non-deterministic temp file extraction — no API changes |

</details>