### PR TITLE
fix(security): bump axios override to ^1.15.0 in examples/js (CVE-2025-62718, ENG-14393)

### DIFF
--- a/examples/js/package-lock.json
+++ b/examples/js/package-lock.json
@@ -791,14 +791,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2229,10 +2229,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/examples/js/package.json
+++ b/examples/js/package.json
@@ -24,7 +24,7 @@
     "playwright-dompath": "^0.0.7"
   },
   "overrides": {
-    "axios": ">=1.13.5 <1.14.1",
+    "axios": "^1.15.0",
     "flatted": "^3.4.2",
     "minimatch": "^3.1.3"
   }


### PR DESCRIPTION
## Summary

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| axios (override) | >=1.13.5 <1.14.1 | ^1.15.0 | CVE-2025-62718 | 8.2 | ✅ Fixed |

## Context

`axios` is a transitive dependency via the `agentql` npm package. A previous commit (commit #146) added an override `"axios": ">=1.13.5 <1.14.1"` to exclude the compromised `1.14.0` build.

`1.14.1` was already the clean replacement, but the override upper bound excluded all subsequent releases. `1.15.0` is the first release on the patched axios branch post-compromise and aligns with the org-wide minimum floor applied across other repos.

Lock resolves to `axios 1.15.0`.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| axios | 1.13.6 (resolved) | 1.15.0 | Security | CVE-2025-62718 fix; override upper bound removed; no breaking changes in 1.x |

</details>