### PR TITLE
fix(security): bump lodash 4.17.23 → 4.18.1 in examples/js (ENG-14277)

### DIFF
--- a/examples/js/package-lock.json
+++ b/examples/js/package-lock.json
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/js/package.json
+++ b/examples/js/package.json
@@ -26,6 +26,7 @@
   "overrides": {
     "axios": "^1.15.0",
     "flatted": "^3.4.2",
+    "lodash": "^4.18.0",
     "minimatch": "^3.1.3"
   }
 }


### PR DESCRIPTION
## Vulnerability Fixes

| Package | Old | New | Advisory | CVSS | Ticket | Status |
|---------|-----|-----|----------|------|--------|--------|
| lodash | 4.17.23 | 4.18.1 | GHSA-r5fr-rjxr-66jc (CVE-2026-4800) | High | ENG-14277 | ✅ Fixed |

## Changes

- `examples/js/package.json`: adds `"lodash": "^4.18.0"` to `overrides` (transitive dep)
- `examples/js/package-lock.json`: regenerated — lodash resolved to 4.18.1

> Supersedes Dependabot PR for alert #39.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| lodash | 4.17.23 | 4.18.1 | Patch/security | GHSA-r5fr-rjxr-66jc code injection fix for `_.template` — no API changes; examples only, not application code |

</details>