### PR TITLE
fix(security): bump follow-redirects 1.15.x → 1.16.0 in examples/js (ENG-14502)

### DIFF
--- a/examples/js/package-lock.json
+++ b/examples/js/package-lock.json
@@ -1410,9 +1410,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/examples/js/package.json
+++ b/examples/js/package.json
@@ -26,6 +26,7 @@
   "overrides": {
     "axios": "^1.15.0",
     "flatted": "^3.4.2",
+    "follow-redirects": "^1.16.0",
     "lodash": "^4.18.0",
     "minimatch": "^3.1.3"
   }


### PR DESCRIPTION
## Vulnerability Fixed

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| follow-redirects | 1.15.11 | 1.16.0 | [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) | MEDIUM | ✅ Fixed |

Linear: ENG-14502

## Root Cause

`follow-redirects <=1.15.11` only strips `authorization`, `proxy-authorization`, and `cookie` headers on cross-domain redirects. Custom auth headers (e.g. `X-API-Key`, `X-Auth-Token`) are forwarded verbatim to the redirect target. Fix: `>=1.16.0`.

`follow-redirects` is a transitive dependency via `axios` in `examples/js/`.

## Fix

Added `"follow-redirects": "^1.16.0"` to `overrides` in `examples/js/package.json`. Regenerated `package-lock.json` — resolves to `1.16.0`.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| follow-redirects | 1.15.11 | 1.16.0 | Security | Strips all non-standard headers on cross-domain redirect. No breaking changes for standard usage |

</details>