### PR TITLE
fix(examples): surface navigation errors in ecommerce pricing pagination

### DIFF
--- a/examples/python/collect_ecommerce_pricing_data/main.py
+++ b/examples/python/collect_ecommerce_pricing_data/main.py
@@ -106,8 +106,8 @@ async def _go_to_the_next_page(page: Page) -> bool:
             next_page_url = URL + next_page_url  # Make it a full URL
         await page.goto(next_page_url)
         return True
-    except Exception:
-        pass
+    except Exception as error:
+        print(f"Failed to navigate to the next page: {error}")
 
     return False
 


### PR DESCRIPTION
## Summary
The `_go_to_the_next_page` helper in the e-commerce pricing example caught every exception from `page.goto()` with a bare `except Exception: pass`, silently swallowing real navigation failures. This change keeps the same control flow but prints the caught error before returning `False`.

## Why it matters
If `page.goto()` fails for a genuine reason (network error, timeout, blocked navigation), the current code silently treats it as "no more pages" and stops pagination with no signal, so an operator sees a truncated result set and cannot tell a real failure from a normal end-of-results.

## Testing
Static review only: traced the single caller (`extract_pricing_data`) and confirmed by inspection that it branches solely on the boolean return value, so adding a diagnostic `print` on the existing error path preserves all return values and control flow while making swallowed errors visible. No repo code, tests, or commands were executed.